### PR TITLE
chore(gitignore): Cleanup .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,7 @@
 *.iml
 /vendor/
 /build/
-node_modules/
-/.php_cs.cache
-js/*hot-update.*
-/model
+/node_modules/
+/.php-cs-fixer.cache
+/js/
 /python


### PR DESCRIPTION
The entire js directory should be ignored and the model directory doesn't seem to be used anymore. The PHP cs fixer file name was wrong.