### PR TITLE
fix(command): Set model to required for download-model command

### DIFF
--- a/.github/workflows/summarize-test.yml
+++ b/.github/workflows/summarize-test.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Download models
         run: |
-          ./occ llm:download-model
+          ./occ llm:download-model llama-2
 
       - name: Run transcription
         run: |

--- a/lib/Command/DownloadModels.php
+++ b/lib/Command/DownloadModels.php
@@ -31,7 +31,7 @@ class DownloadModels extends Command {
 		$this->setName('llm:download-model')
 			->setDescription('Download the necessary machine learning model (~4GB)');
 		$this->addOption('force', 'f', InputOption::VALUE_NONE, 'Force download even if the model(s) are downloaded already');
-		$this->addArgument('model', InputArgument::OPTIONAL, 'Choose the model to download, either "llama-2" (default) or "gpt4all-falcon"', DownloadModelsService::MODEL_LLAMA);
+		$this->addArgument('model', InputArgument::REQUIRED, 'Choose the model to download: '. implode(", ", array_keys(DownloadModelsService::MODELS)));
 	}
 
 	/**


### PR DESCRIPTION
This command really confused me. I expected that it either requires me to give the model or downloads the one I selected in the admin settings. It was not intuitive that it did neither of them and had it's own default.